### PR TITLE
Clean up SHA tag for messy github output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -125,19 +125,13 @@ runs:
         labels: |
           org.opencontainers.image.source=https://github.com/${{ inputs.organization }}/${{ inputs.repository }}
 
-    - name: 'Install jq 1.6'
-      uses: dcarbone/install-jq-action@v1.0.1
-      with:
-        version: 1.6
-        force: 'true'
-
-    - uses: edwardgeorge/jq-action@main
-      id: tag
-      with:
-        compact: true
-        raw-output: true
-        input: ${{ steps.meta.outputs.json }}
-        script: '.tags | map(select(test("sha-\\w{8,}"))) | first | match("sha-\\w{8,}") | .string'
+    - name: Pull out SHA tag
+      id: sha
+      shell: bash
+      run: |
+        sha=$(echo '${{ steps.meta.outputs.json }}' | jq -r '.tags | map(select(test("sha-\\w{8,}"))) | first | match("sha-\\w{8,}") | .string')
+        echo "sha=$sha" >> $GITHUB_OUTPUT
+        echo "Docker image SHA: $sha"
 
     # docker context must be created prior to setting up Docker Buildx
     # https://github.com/actions-runner-controller/actions-runner-controller/issues/893

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ outputs:
     value: ${{ inputs.registry }}/${{ steps.image_name.outputs.image_name }}
   tag:
     description: "Docker image tag"
-    value: ${{ steps.tag.outputs.output }}
+    value: ${{ steps.tag.outputs.sha }}
   metadata:
     description: "Docker image metadata"
     value: ${{ steps.get-metadata.outputs.metadata }}
@@ -126,7 +126,7 @@ runs:
           org.opencontainers.image.source=https://github.com/${{ inputs.organization }}/${{ inputs.repository }}
 
     - name: Pull out SHA tag
-      id: sha
+      id: tag
       shell: bash
       run: |
         sha=$(echo '${{ steps.meta.outputs.json }}' | jq -r '.tags | map(select(test("sha-\\w{8,}"))) | first | match("sha-\\w{8,}") | .string')


### PR DESCRIPTION
This cleans up the `jq` lines that were causing deprecation warnings (`set-output` calls, old node 12). `jq` should be installed on the base image already as a convenience, and this removes some questionable/abandoned dependencies.

If this works well, I will PR this against the fork as well.