### PR TITLE
Pin to buildkx 0.15.2 to avoid bad-file-descriptor issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,6 +148,7 @@ runs:
       uses: docker/setup-buildx-action@v3
       with:
         endpoint: buildx-context
+        version: v0.15.2
 
     - name: Login
       uses: docker/login-action@v3


### PR DESCRIPTION
See: https://github.com/docker/buildx/issues/2593